### PR TITLE
Add site search using DuckDuckGo

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700%7CPT+Sans:400">
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/public/apple-touch-icon-precomposed.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/public/apple-touch-icon.png">
   <link rel="shortcut icon" href="{{ site.baseurl }}/public/favicon.ico">
 
   <!-- RSS -->

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -28,6 +28,12 @@
     <a class="sidebar-nav-item" href="{{ site.github.repository_url }}">GitHub project</a>
   </nav>
 
+  <form class="search" action="https://duckduckgo.com/" method="get">
+    <label for="q">Search this site</label>
+    <input type="hidden" name="sites" value="https://mozilla.github.io/meao/">
+    <input class="search-input" type="search" name="q" id="q" placeholder="Powered by DuckDuckGo">
+  </form>
+
   <div class="sidebar-item">
     <p>
       &copy; {{ site.time | date: '%Y' }}. All rights reserved.

--- a/public/css/lanyon.css
+++ b/public/css/lanyon.css
@@ -259,6 +259,28 @@ a.sidebar-nav-item:focus {
   }
 }
 
+.sidebar .search {
+  padding: .5rem 1.5rem;
+}
+
+.sidebar .search label {
+  display: block;
+  margin-bottom: .25rem;
+}
+
+.sidebar .search-input {
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,.1);
+  font-size: .65rem;
+  height: 1.5rem;
+  line-height: 1.5rem;
+  padding: 0 .2rem;
+  width: 100%;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+}
+
 /* Slide effect
  *
  * Handle the sliding effects of the sidebar and content in one spot, seperate


### PR DESCRIPTION
- Adds a site search form to the side bar using DuckDuckGo :duck: 
- Also fixes a 404 on the Apple touch icon.