### PR TITLE
docker-run.sh works, it just is real slow now

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This is the source code repository for the
 ./docker-run.sh
 ```
 
+This will take 2-3 minutes to start on macOS, with no output, due to a slow
+``chmod`` operation in the Jekyll image.
+
 The site (with drafts) is available at http://localhost:4000/meao/
 
 ## Run with Ruby

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,3 +1,8 @@
 #!/bin/bash -ex
 
-docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll -it -p 4000:4000 jekyll/jekyll:pages jekyll serve --watch --drafts
+export JEKYLL_VERSION=3.5
+export JEKYLL_DEBUG=1
+export JEKYLL_UID=$(id -u)
+CMD="jekyll serve --watch --drafts"
+echo "It will take 2-3 minutes, with no output, to start on macOS."
+docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll -it -p 4000:4000 jekyll/jekyll:$JEKYLL_VERSION $CMD


### PR DESCRIPTION
Update docs so macOS users don't give up.